### PR TITLE
Use forked repo for docker error

### DIFF
--- a/vars/kubernetesDeploy.groovy
+++ b/vars/kubernetesDeploy.groovy
@@ -12,7 +12,7 @@ def call(Map conf, Map opts = [:]) {
   def Integer daemonSetSleep = opts['daemonSetSleep'] ?: 20
 
   def String k8sCluster = opts['k8sCluster'] ?: ''
-  def String k8sVersion = opts['k8sVersion'] ?: 'v1.6.2'
+  def String k8sVersion = opts['k8sVersion'] ?: 'latest'
   def String k8sNamespace = conf['K8S_NAMESPACE'] ?: ''
   def String dockerRegistry = conf['DOCKER_REGISTRY']
   def String dockerEmail = conf['DOCKER_EMAIL'] ?: 'test@example.com'
@@ -31,7 +31,7 @@ def call(Map conf, Map opts = [:]) {
     }
 
     withCredentials(credentials) {
-      docker.image("lachlanevenson/k8s-kubectl:${k8sVersion}").inside("-u root:root") {
+      docker.image("mskjeret/k8s-kubectl:${k8sVersion}").inside("-u root:root") {
         if (apply) {
           sh """
             set -u


### PR DESCRIPTION
After upgrading jenkins and plugins to the latest version the kubectl docker image do not work anymore.

It seems that the image use a different command between entrypoint.sh and the CMD in the docker file. 
There is some logic in the docker implementation in jenkins that determines if a image is running, which fails for this repo.

I will issue a pull request to the main repo so that we can remove the forked repo soon.
